### PR TITLE
Misc Target Cleanup

### DIFF
--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -17,7 +17,7 @@ set(CMAKE_SYSTEM_VERSION 1)
 set(YOTTA_FORCE_INCLUDE_FLAG "-include")
 
 # provide compatibility definitions for compiling with this target: these are
-# definitions that legacy code assumes will be defined. 
+# definitions that legacy code assumes will be defined.
 add_definitions("-DTOOLCHAIN_GCC")
 
 macro(_gcc_not_found progname)
@@ -51,7 +51,12 @@ macro(gcc_load_toolchain prefix)
     set(YOTTA_POSTPROCESS_COMMAND "\"${K_OBJCOPY}\" -O binary YOTTA_CURRENT_EXE_NAME YOTTA_CURRENT_EXE_NAME.bin")
 
     # set default compilation flags
-    set(_C_FAMILY_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wall -Wextra -gstrict-dwarf")
+    IF(CMAKE_BUILD_TYPE MATCHES Debug)
+        set(_C_FAMILY_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wall -Wextra -gstrict-dwarf")
+    ELSE()
+        set(_C_FAMILY_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wextra -gstrict-dwarf")
+    ENDIF()
+
     set(CMAKE_C_FLAGS_INIT   "${_C_FAMILY_FLAGS_INIT}")
     set(CMAKE_ASM_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -x assembler-with-cpp")
     set(CMAKE_CXX_FLAGS_INIT "--std=gnu++11 ${_C_FAMILY_FLAGS_INIT} -fno-rtti -fno-threadsafe-statics")

--- a/target.json
+++ b/target.json
@@ -39,9 +39,15 @@
               "txQueueLen": 32
           }
       },
-      "spiCount": 1,
-      "defaults": {
-        "spi": "K_SPI1"
+      "spi": {
+          "count": 0,
+          "defaults": {
+              "bus": "K_SPI1",
+              "role": "K_SPI_MASTER",
+              "direction": "K_SPI_DIRECTION_2LINES",
+              "dataSize": "K_SPI_DATASIZE_8BIT",
+              "speed": "10000"
+          }
       }
     }
   },

--- a/target.json
+++ b/target.json
@@ -20,7 +20,7 @@
   "config": {
     "hardware": {
       "i2c": {
-        "count": 1,
+        "count": 0,
         "defaults": {
             "bus": "K_I2C1",
             "role": "K_MASTER",

--- a/target.json
+++ b/target.json
@@ -19,6 +19,15 @@
   ],
   "config": {
     "hardware": {
+      "i2c": {
+        "count": 1,
+        "defaults": {
+            "bus": "K_I2C1",
+            "role": "K_MASTER",
+            "clockSpeed": 100000,
+            "addressingMode": "K_ADDRESSINGMODE_7BIT"
+        }
+      },
       "uart": {
           "count": 0,
           "defaults": {
@@ -30,10 +39,8 @@
               "txQueueLen": 32
           }
       },
-      "i2cCount": 1,
       "spiCount": 1,
       "defaults": {
-        "i2c": "K_I2C1",
         "spi": "K_SPI1"
       }
     }

--- a/target.json
+++ b/target.json
@@ -19,17 +19,19 @@
   ],
   "config": {
     "hardware": {
-      "uartCount": 0,
+      "uart": {
+          "count": 0,
+          "defaults": {
+              "baudRate": 9600,
+              "wordLen": "K_WORD_LEN_8BIT",
+              "stopBits": "K_STOP_BITS_1",
+              "parity": "K_PARITY_NONE",
+              "rxQueueLen": 32,
+              "txQueueLen": 32
+          }
+      },
       "i2cCount": 1,
       "spiCount": 1,
-      "uartDefaults": {
-        "baudRate": 9600,
-        "wordLen": "K_WORD_LEN_8BIT",
-        "stopBits": "K_STOP_BITS_1",
-        "parity": "K_PARITY_NONE",
-        "rxQueueLen": 32,
-        "txQueueLen": 32
-      }, 
       "defaults": {
         "i2c": "K_I2C1",
         "spi": "K_SPI1"

--- a/target.json
+++ b/target.json
@@ -46,6 +46,9 @@
               "role": "K_SPI_MASTER",
               "direction": "K_SPI_DIRECTION_2LINES",
               "dataSize": "K_SPI_DATASIZE_8BIT",
+              "clockPolarity": "K_SPI_CPOL_HIGH",
+              "clockPhase": "K_SPI_CPHA_1EDGE",
+              "firstBit": "K_SPI_FIRSTBIT_LSB",
               "speed": "10000"
           }
       }


### PR DESCRIPTION
* Moved the `-Wall` option into just debug builds (KUBOS-67)
* Consolidated the uart/spi/i2c configuration options (KUBOS-64)
* Added default init values for i2c (KUBOS-64)
* Added default init values and new config options for spi (KUBOS-64, KUBOS-65)